### PR TITLE
Feat/mmr candidates api

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,23 @@ stats := db.GetStats()
 // MMR: relevant but diverse results (optional; see Performance section)
 results, err = db.SearchMMR(queryVector, 5)
 results, err = db.SearchMMR(queryVector, 5, &serverlessVector.MMROptions{Lambda: 0.7, FetchFactor: 5})
+
+// Advanced MMR: External scores and Candidate sets
+// 1. Run MMR on a provided set of candidates (ignoring DB storage)
+candidates := []serverlessVector.MMRCandidate{
+    {ID: "A", Embedding: []float32{...}, BaseScore: 0.9},
+    {ID: "B", Embedding: []float32{...}, BaseScore: 0.8},
+}
+results, err = db.SelectMMRFromCandidates(candidates, 5, &serverlessVector.MMROptions{Lambda: 0.5})
+
+// 2. Search with external base scores (blending or overriding query similarity)
+baseScores := map[string]float64{"doc1": 1.0, "doc2": 0.5}
+// Blend query similarity (0.5) and base score (0.5)
+results, err = db.SearchMMRWithScores(query, 5, baseScores, &serverlessVector.MMROptions{
+    Lambda: 0.6,
+    ScoreMode: serverlessVector.MMRScoreBlend,
+    BlendAlpha: 0.5,
+})
 ```
 
 ## Performance
@@ -97,6 +114,10 @@ Benchmarks on Apple M1. Scale roughly with n and d. For **L2-normalised** embedd
 **Memory (per vector / 10K vectors)** — 128D: 0.5KB / 27MB · 384D: 1.5KB / 76MB · 768D: 3KB / 149MB · 1536D: 6KB / 295MB
 
 **SearchMMR** — Balances relevance and diversity. ~1.4ms (2.9x Search) at 1K vectors 128D, topK=10. `SearchMMR(query, topK)` or add `&MMROptions{Lambda: 0.7, FetchFactor: 5}` to tune.
+
+**SelectMMRFromCandidates** — Run MMR on a provided set of candidates (ignoring DB storage). Useful for re-ranking external search results.
+
+**SearchMMRWithScores** — Standard MMR search but with external base scores (e.g. from a keyword search or other signals). Supports `QueryOnly`, `BaseScoreOnly`, and `Blend` modes.
 
 **Throughput (1K vectors, topK=10, cosine)** — Takara ds1-en-v1 512D (use DotProduct): ~3600/s · OpenAI 1536D: ~170/s · Sentence Transformers 384–768D: ~330–670/s · 128D: ~2000/s
 

--- a/lib/distance.go
+++ b/lib/distance.go
@@ -24,7 +24,8 @@ func norm32(a []float32) float64 {
 	return math.Sqrt(dotProduct32(a, a))
 }
 
-func (db *VectorDB) distanceFloat32(a, b []float32, distanceFunc DistanceFunction) float64 {
+// DistanceFloat32 computes the distance/similarity between two vectors.
+func DistanceFloat32(a, b []float32, distanceFunc DistanceFunction) float64 {
 	switch distanceFunc {
 	case CosineSimilarity:
 		dot := dotProduct32(a, b)
@@ -42,6 +43,10 @@ func (db *VectorDB) distanceFloat32(a, b []float32, distanceFunc DistanceFunctio
 	default:
 		return dotProduct32(a, b)
 	}
+}
+
+func (db *VectorDB) distanceFloat32(a, b []float32, distanceFunc DistanceFunction) float64 {
+	return DistanceFloat32(a, b, distanceFunc)
 }
 
 func sameLen32(a, b []float32) bool { return len(a) == len(b) }

--- a/lib/search.go
+++ b/lib/search.go
@@ -102,7 +102,131 @@ func (db *VectorDB) SearchMMRParams(query any, topK int, lambda float64, fetchFa
 	return db.searchMMRCore(query, topK, lambda, ff)
 }
 
+// SelectMMRFromCandidates runs MMR over a provided candidate set.
+// It uses db only for its DistanceFunction. FetchFactor is ignored.
+// Callers must pass normalized embeddings if using CosineSimilarity.
+func (db *VectorDB) SelectMMRFromCandidates(candidates []MMRCandidate, topK int, opts *MMROptions) (*SearchResult, error) {
+	if topK <= 0 {
+		topK = 10
+	}
+	if len(candidates) == 0 {
+		return &SearchResult{Results: []SimilarityResult{}, Total: 0}, nil
+	}
+	lambda := 0.6
+	if opts != nil && opts.Lambda > 0 {
+		lambda = math.Max(0, math.Min(1, opts.Lambda))
+	}
+
+	candResults := make(map[string]SimilarityResult, len(candidates))
+	candVecs := make(map[string][]float32, len(candidates))
+	relevance := make(map[string]float64, len(candidates))
+
+	for _, c := range candidates {
+		// Treat negative/NaN BaseScore as 0
+		score := c.BaseScore
+		if math.IsNaN(score) || score < 0 {
+			score = 0
+		}
+		relevance[c.ID] = score
+		candVecs[c.ID] = c.Embedding
+		candResults[c.ID] = SimilarityResult{
+			ID:    c.ID,
+			Score: c.BaseScore, // Keep base score in result
+			// Metadata empty
+		}
+	}
+
+	return mmrGreedy(candResults, candVecs, relevance, topK, lambda, db.distFunc)
+}
+
+// SearchMMRWithScores runs MMR with custom relevance scoring (QueryOnly, BaseScoreOnly, or Blend).
+// When baseScores are provided, they can override or blend with query similarity.
+func (db *VectorDB) SearchMMRWithScores(query any, topK int, baseScores map[string]float64, opts *MMROptions) (*SearchResult, error) {
+	if topK <= 0 {
+		topK = 10
+	}
+	lambda := 0.6
+	ff := 5
+	var scoreMode MMRScoreMode
+	var blendAlpha float64
+
+	if opts != nil {
+		if opts.Lambda > 0 {
+			lambda = math.Max(0, math.Min(1, opts.Lambda))
+		}
+		if opts.FetchFactor > 0 {
+			ff = opts.FetchFactor
+		}
+		scoreMode = opts.ScoreMode
+		blendAlpha = opts.BlendAlpha
+	}
+
+	// 1. Get candidates via standard search
+	candidateK := topK * ff
+	candidates, err := db.searchCore(query, candidateK, true, nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(candidates.Results) == 0 {
+		return &SearchResult{Results: []SimilarityResult{}, Total: 0}, nil
+	}
+
+	// 2. Resolve candidate vectors
+	candVecs := make(map[string][]float32, len(candidates.Results))
+	db.mu.RLock()
+	for _, r := range candidates.Results {
+		v, ok := db.vectors[r.ID]
+		if ok {
+			candVecs[r.ID] = v.Data
+		}
+	}
+	db.mu.RUnlock()
+	if len(candVecs) != len(candidates.Results) {
+		return nil, errors.New("MMR: could not resolve all candidate vectors")
+	}
+
+	// 3. Compute relevance based on scoreMode
+	toRelevance := func(score float64) float64 {
+		switch db.distFunc {
+		case EuclideanDistance, ManhattanDistance:
+			return 1.0 / (1.0 + score)
+		default:
+			return score
+		}
+	}
+
+	relevance := make(map[string]float64, len(candidates.Results))
+	candResults := make(map[string]SimilarityResult, len(candidates.Results))
+
+	for _, r := range candidates.Results {
+		candResults[r.ID] = r
+		queryRel := toRelevance(r.Score)
+		baseScore := 0.0
+		if baseScores != nil {
+			baseScore = baseScores[r.ID] // missing treats as 0
+		}
+
+		var finalRel float64
+		switch scoreMode {
+		case MMRScoreQueryOnly:
+			finalRel = queryRel
+		case MMRScoreBaseOnly:
+			finalRel = baseScore
+		case MMRScoreBlend:
+			finalRel = blendAlpha*queryRel + (1.0-blendAlpha)*baseScore
+		default:
+			finalRel = queryRel
+		}
+		relevance[r.ID] = finalRel
+	}
+
+	return mmrGreedy(candResults, candVecs, relevance, topK, lambda, db.distFunc)
+}
+
 func (db *VectorDB) searchMMRCore(query any, topK int, lambda float64, ff int) (*SearchResult, error) {
+	// Re-implement searchMMRCore using SearchMMRWithScores logic (QueryOnly mode)
+	// or directly call mmrGreedy to share code.
+
 	if topK <= 0 {
 		topK = 10
 	}
@@ -115,16 +239,22 @@ func (db *VectorDB) searchMMRCore(query any, topK int, lambda float64, ff int) (
 	if len(candidates.Results) == 0 {
 		return &SearchResult{Results: []SimilarityResult{}, Total: 0}, nil
 	}
+	// Note: Original searchMMRCore had a check `if len(candidates.Results) <= topK { return candidates, nil }`
+	// but strictly speaking, even if we have fewer candidates, MMR re-ranking might change order if lambda < 1?
+	// Actually if K <= topK, we select all of them. The order might change though.
+	// The original code returned early, implying order from searchCore (similarity) is accepted if we don't have enough candidates to pick from?
+	// But MMR is about diversity. If I have 3 results and topK=10, do I want them re-ordered by diversity?
+	// Original code returned candidates directly. I will preserve this behavior.
 	if len(candidates.Results) <= topK {
 		return candidates, nil
 	}
 
-	candVecs := make(map[string]*Vector, len(candidates.Results))
+	candVecs := make(map[string][]float32, len(candidates.Results))
 	db.mu.RLock()
 	for _, r := range candidates.Results {
 		v, ok := db.vectors[r.ID]
 		if ok {
-			candVecs[r.ID] = v
+			candVecs[r.ID] = v.Data
 		}
 	}
 	db.mu.RUnlock()
@@ -141,38 +271,67 @@ func (db *VectorDB) searchMMRCore(query any, topK int, lambda float64, ff int) (
 		}
 	}
 
-	relevanceToQuery := make(map[string]float64)
+	relevance := make(map[string]float64, len(candidates.Results))
+	candResults := make(map[string]SimilarityResult, len(candidates.Results))
 	for _, r := range candidates.Results {
-		relevanceToQuery[r.ID] = toRelevance(r.Score)
+		candResults[r.ID] = r
+		relevance[r.ID] = toRelevance(r.Score)
+	}
+
+	return mmrGreedy(candResults, candVecs, relevance, topK, lambda, db.distFunc)
+}
+
+// mmrGreedy implements the shared greedy selection loop.
+func mmrGreedy(
+	candidates map[string]SimilarityResult,
+	vectors map[string][]float32,
+	relevance map[string]float64,
+	topK int,
+	lambda float64,
+	distFunc DistanceFunction,
+) (*SearchResult, error) {
+	toRelevance := func(score float64) float64 {
+		switch distFunc {
+		case EuclideanDistance, ManhattanDistance:
+			return 1.0 / (1.0 + score)
+		default:
+			return score
+		}
 	}
 
 	selected := make([]SimilarityResult, 0, topK)
-	remaining := make(map[string]SimilarityResult)
-	for _, r := range candidates.Results {
-		remaining[r.ID] = r
+	remaining := make(map[string]SimilarityResult, len(candidates))
+	for id, r := range candidates {
+		remaining[id] = r
 	}
 
+	// For loop
 	for len(selected) < topK && len(remaining) > 0 {
 		var bestID string
 		bestMMR := math.Inf(-1)
+
 		for id := range remaining {
-			relQ := relevanceToQuery[id]
+			rel := relevance[id]
 			maxSimToSelected := 0.0
-			vecD := candVecs[id]
+			vecD := vectors[id]
+
 			for _, s := range selected {
-				vecS := candVecs[s.ID]
-				raw := db.distanceFloat32(vecD.Data, vecS.Data, db.distFunc)
+				vecS := vectors[s.ID]
+				// Use package-level DistanceFloat32 to avoid DB dependency
+				raw := DistanceFloat32(vecD, vecS, distFunc)
 				sim := toRelevance(raw)
 				if sim > maxSimToSelected {
 					maxSimToSelected = sim
 				}
 			}
-			mmrScore := lambda*relQ - (1.0-lambda)*maxSimToSelected
+
+			mmrScore := lambda*rel - (1.0-lambda)*maxSimToSelected
 			if mmrScore > bestMMR {
 				bestMMR = mmrScore
 				bestID = id
 			}
 		}
+
 		if bestID == "" {
 			break
 		}

--- a/lib/types.go
+++ b/lib/types.go
@@ -90,8 +90,29 @@ type SearchResult struct {
 
 // MMROptions configures Maximal Marginal Relevance search. Nil or zero values use defaults.
 type MMROptions struct {
-	Lambda      float64 // Balance relevance (1) vs diversity (0). Default 0.6.
-	FetchFactor int     // Candidate pool size = FetchFactor * topK. Default 5.
+	Lambda      float64      // Balance relevance (1) vs diversity (0). Default 0.6.
+	FetchFactor int          // Candidate pool size = FetchFactor * topK. Default 5.
+	ScoreMode   MMRScoreMode // Mode for relevance scoring (QueryOnly, BaseScoreOnly, or Blend).
+	BlendAlpha  float64      // Alpha for Blend mode: relevance = Alpha*querySim + (1-Alpha)*baseScore.
+}
+
+// MMRScoreMode defines how relevance is computed in MMR.
+type MMRScoreMode int
+
+const (
+	// MMRScoreQueryOnly uses query similarity as relevance (default behavior).
+	MMRScoreQueryOnly MMRScoreMode = iota
+	// MMRScoreBaseOnly uses caller-provided BaseScore as relevance (ignoring query similarity).
+	MMRScoreBaseOnly
+	// MMRScoreBlend uses a weighted blend of query similarity and BaseScore.
+	MMRScoreBlend
+)
+
+// MMRCandidate represents a candidate for MMR selection provided by the caller.
+type MMRCandidate struct {
+	ID        string
+	Embedding []float32
+	BaseScore float64 // External relevance score. Negative/NaN treated as 0.
 }
 
 // String returns a string representation of the distance function

--- a/serverless_vector.go
+++ b/serverless_vector.go
@@ -29,6 +29,12 @@ type SimilarityResult = lib.SimilarityResult
 // MMROptions configures MMR search; nil uses defaults
 type MMROptions = lib.MMROptions
 
+// MMRScoreMode defines how relevance is computed in MMR
+type MMRScoreMode = lib.MMRScoreMode
+
+// MMRCandidate represents a candidate for MMR selection
+type MMRCandidate = lib.MMRCandidate
+
 // Vector type constant (float32 only, matches embedding APIs)
 const Float32 VectorType = lib.Float32
 
@@ -38,6 +44,13 @@ const (
 	DotProduct        DistanceFunction = lib.DotProduct
 	EuclideanDistance DistanceFunction = lib.EuclideanDistance
 	ManhattanDistance DistanceFunction = lib.ManhattanDistance
+)
+
+// Constants for MMR score modes
+const (
+	MMRScoreQueryOnly MMRScoreMode = lib.MMRScoreQueryOnly
+	MMRScoreBaseOnly  MMRScoreMode = lib.MMRScoreBaseOnly
+	MMRScoreBlend     MMRScoreMode = lib.MMRScoreBlend
 )
 
 // NewVectorDB creates a new vector database

--- a/vector_generic_test.go
+++ b/vector_generic_test.go
@@ -257,6 +257,134 @@ func TestSearchMMR(t *testing.T) {
 	}
 }
 
+func TestSelectMMRFromCandidates(t *testing.T) {
+	// Use DotProduct for simpler manual calculation (no norm)
+	db := NewVectorDB(3, DotProduct)
+
+	// Candidates:
+	// A: BaseScore=1.0, Vector=[1,0,0]
+	// B: BaseScore=0.9, Vector=[1,0,0] (Very similar to A)
+	// C: BaseScore=0.8, Vector=[0,1,0] (Orthogonal to A)
+	candidates := []MMRCandidate{
+		{ID: "A", BaseScore: 1.0, Embedding: []float32{1, 0, 0}},
+		{ID: "B", BaseScore: 0.9, Embedding: []float32{1, 0, 0}},
+		{ID: "C", BaseScore: 0.8, Embedding: []float32{0, 1, 0}},
+	}
+
+	// 1. Lambda=1 (Pure BaseScore relevance)
+	// Should pick A (1.0), then B (0.9), then C (0.8)
+	res1, err := db.SelectMMRFromCandidates(candidates, 3, &MMROptions{Lambda: 1.0})
+	if err != nil {
+		t.Fatalf("SelectMMR failed: %v", err)
+	}
+	if len(res1.Results) != 3 {
+		t.Fatalf("Expected 3 results, got %d", len(res1.Results))
+	}
+	if res1.Results[0].ID != "A" || res1.Results[1].ID != "B" || res1.Results[2].ID != "C" {
+		t.Errorf("Lambda=1 expected A, B, C; got %v", res1.Results)
+	}
+
+	// 2. Lambda=0.5 (Diversity matters)
+	// Pick 1: A (highest score 1.0)
+	// Pick 2:
+	//   B: rel=0.9, sim(A,B)=1.0 -> 0.5*0.9 - 0.5*1.0 = -0.05
+	//   C: rel=0.8, sim(A,C)=0.0 -> 0.5*0.8 - 0.5*0.0 = 0.40
+	// So C should be picked second.
+	res2, err := db.SelectMMRFromCandidates(candidates, 3, &MMROptions{Lambda: 0.5})
+	if err != nil {
+		t.Fatalf("SelectMMR failed: %v", err)
+	}
+	if res2.Results[0].ID != "A" {
+		t.Errorf("First result should be A, got %s", res2.Results[0].ID)
+	}
+	if res2.Results[1].ID != "C" {
+		t.Errorf("Second result should be C (diversity), got %s", res2.Results[1].ID)
+	}
+	if res2.Results[2].ID != "B" {
+		t.Errorf("Third result should be B, got %s", res2.Results[2].ID)
+	}
+}
+
+func TestSearchMMRWithScores(t *testing.T) {
+	db := NewVectorDB(3, DotProduct)
+	_ = db.Add("A", []float32{1, 0, 0})
+	_ = db.Add("B", []float32{1, 0, 0}) // Same as A
+	_ = db.Add("C", []float32{0, 1, 0}) // Orthogonal
+
+	query := []float32{1, 0, 0}
+	// Query Similarity: A=1, B=1, C=0
+
+	// 1. QueryOnly (Default) - Regression check
+	// Should behave like standard SearchMMR
+	// Lambda=0.4
+	// A: 1.0. Pick A.
+	// B: rel=1.0, sim=1.0 -> 0.4*1 - 0.6*1 = -0.2
+	// C: rel=0.0, sim=0.0 -> 0.0
+	// C > B. So A, C, B.
+	resQ, err := db.SearchMMRWithScores(query, 3, nil, &MMROptions{Lambda: 0.4, ScoreMode: MMRScoreQueryOnly})
+	if err != nil {
+		t.Fatalf("SearchMMRWithScores failed: %v", err)
+	}
+	if resQ.Results[0].ID != "A" && resQ.Results[0].ID != "B" {
+		t.Errorf("First should be A or B")
+	}
+	if resQ.Results[1].ID != "C" {
+		t.Errorf("Second should be C (diversity), got %s", resQ.Results[1].ID)
+	}
+
+	// 2. BaseScoreOnly
+	// Base Scores: C=1.0, A=0.0, B=0.0
+	// Pick 1: C (1.0)
+	// Pick 2:
+	//   A: rel=0.0, sim(C,A)=0.0 -> 0.4*0 - 0.6*0 = 0
+	//   B: rel=0.0, sim(C,B)=0.0 -> 0
+	// Order: C, then A/B.
+	baseScores := map[string]float64{
+		"C": 1.0,
+		"A": 0.0,
+		"B": 0.0,
+	}
+	resB, err := db.SearchMMRWithScores(query, 3, baseScores, &MMROptions{Lambda: 0.5, ScoreMode: MMRScoreBaseOnly})
+	if err != nil {
+		t.Fatalf("SearchMMRWithScores failed: %v", err)
+	}
+	if resB.Results[0].ID != "C" {
+		t.Errorf("BaseScoreOnly: expected C first (score 1.0), got %s", resB.Results[0].ID)
+	}
+
+	// 3. Blend
+	// Base: A=0.2, B=0.0, C=1.0
+	// Alpha=0.5
+	// Rel A = 0.5*1 + 0.5*0.2 = 0.6
+	// Rel B = 0.5*1 + 0.5*0.0 = 0.5
+	// Rel C = 0.5*0 + 0.5*1.0 = 0.5
+	// Pick 1: A (0.6)
+	// Pick 2:
+	//   B: rel=0.5, sim(A,B)=1.0. MMR = lambda*0.5 - (1-lambda)*1.0.
+	//      If lambda=0.8: 0.8*0.5 - 0.2*1.0 = 0.4 - 0.2 = 0.2
+	//   C: rel=0.5, sim(A,C)=0.0. MMR = 0.8*0.5 - 0.2*0 = 0.4
+	// C (0.4) > B (0.2). So A, C, B.
+	baseScores2 := map[string]float64{
+		"A": 0.2,
+		"B": 0.0,
+		"C": 1.0,
+	}
+	resBlend, err := db.SearchMMRWithScores(query, 3, baseScores2, &MMROptions{
+		Lambda:     0.8,
+		ScoreMode:  MMRScoreBlend,
+		BlendAlpha: 0.5,
+	})
+	if err != nil {
+		t.Fatalf("SearchMMRWithScores failed: %v", err)
+	}
+	if resBlend.Results[0].ID != "A" {
+		t.Errorf("Blend: expected A first, got %s", resBlend.Results[0].ID)
+	}
+	if resBlend.Results[1].ID != "C" {
+		t.Errorf("Blend: expected C second (diversity), got %s", resBlend.Results[1].ID)
+	}
+}
+
 func TestMemoryStats(t *testing.T) {
 	db := NewVectorDB(0) // No dimension validation
 


### PR DESCRIPTION
## Describe your changes
What was changed and why this change was needed

- **What**: Extended the MMR (Maximal Marginal Relevance) API with two new methods and a shared core implementation:
    1.  `SelectMMRFromCandidates`: Runs MMR re-ranking over a caller-provided set of candidates (IDs + embeddings + base scores), decoupling MMR logic from the internal vector storage.
    2.  `SearchMMRWithScores`: Enhances standard MMR search to accept external relevance scores (e.g., from keyword search or other signals) and combine them with vector similarity using `QueryOnly`, `BaseScoreOnly`, or `Blend` modes.
    3.  Refactored the greedy MMR selection logic into a reusable `mmrGreedy` helper and exposed `DistanceFloat32` for use without a DB instance.
    4.  Updated `MMROptions` to support `ScoreMode` and `BlendAlpha`.

- **Why**: To support advanced curation pipelines (like those using turbopuffer or hybrid search) where candidates and relevance scores come from external sources, but the diversity/re-ranking logic of `serverlessVector` is still needed. This allows the library to be used as a pure re-ranking engine or a hybrid search ranker without changing its existing simple API surface area.

## Issue ticket number and link

## Checklist before requesting a review
- [x] PR title follows conventional commit format (e.g., `feat: add user authentication`, `fix: resolve API timeout`)
- [x] I have performed a self-review of my code
- [x] Tests pass
- [x] Documentation updated if needed 